### PR TITLE
Update StationReportDiscordIntergrationSystem.cs

### DIFF
--- a/Content.Goobstation.Server/StationReport/StationReportDiscordIntergrationSystem.cs
+++ b/Content.Goobstation.Server/StationReport/StationReportDiscordIntergrationSystem.cs
@@ -34,6 +34,12 @@ public sealed class StationReportDiscordIntergrationSystem : EntitySystem
 
     private static readonly TagReplacement[] _replacements =
     {
+        // Discord markdown replacements, these must happen BEFORE anything else!
+        new(@"*", @"\*"), // Omu, escape * so it doesn't unintentionally bold stuff in Discord
+        new(@"_", @"\_"), // Omu, escape _ so it doesn't unintentionally italics stuff in Discord
+        new(@"~", @"\~"), // Omu, escape ~ so it doesn't unintentionally strikethrough stuff in Discord
+        new(@"`", @"\`"), // Omu, escape ` so it doesn't unintentionally codeblock stuff in Discord
+        // End of Discord markdown replacements, other stuff can come AFTER this.
         new(@"\[/?bold\]", @"**"),
         new(@"\[/?italic\]", @"_"),
         new(@"\[/?mono\]", @"__"),


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
<!-- What did you change? -->
Added some character escaping for Discord reports
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
This is because using __ in the report will unintentionally make things italics or underlined, etc. This way, any pre-existing *, _, ` and ~ will be escaped, so that they appear in Discord as they did on the paper in-game.


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->


**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognises the changes and adds them to the game's changelog. -->
:cl:
- fix: Fixed station reports unintentionally making lines italic, bold, underline or strikethrough.

